### PR TITLE
Add tests for run_inference.py on specific wav files

### DIFF
--- a/ModelTraining/ModelTraining.pyproj
+++ b/ModelTraining/ModelTraining.pyproj
@@ -40,6 +40,7 @@ MODEL_URL=https://trainedproductionmodels.blob.core.windows.net/dnnmodel/11-15-2
     <Compile Include="src\make_spectrograms.py" />
     <Compile Include="src\model_inference.py" />
     <Compile Include="src\process_humpback_wavs.py" />
+    <Compile Include="src\run_inference.py" />
     <Compile Include="src\spectrogram_visualizer.py" />
     <Compile Include="src\train_huggingface_model.py" />
     <Compile Include="tests\conftest.py" />

--- a/ModelTraining/src/huggingface_inference.py
+++ b/ModelTraining/src/huggingface_inference.py
@@ -311,7 +311,7 @@ class HuggingFaceInference(ModelInference):  # Inherit from ModelInference
         # For every SEGMENT_GROUP_SIZE segments, require at least 1 positive prediction.
         # Cap at min_num_positive_calls_threshold to avoid requiring too many for very long clips.
         total_segments = len(local_predictions)
-        scaled_threshold = (total_segments + SEGMENT_GROUP_SIZE - 1) // SEGMENT_GROUP_SIZE
+        scaled_threshold = max(1, (total_segments + SEGMENT_GROUP_SIZE - 1) // SEGMENT_GROUP_SIZE)
         effective_threshold = min(scaled_threshold, min_num_positive_calls_threshold)
 
         # If we have enough positive predictions, use majority vote among them.

--- a/ModelTraining/src/huggingface_inference.py
+++ b/ModelTraining/src/huggingface_inference.py
@@ -17,6 +17,10 @@ from transformers import Wav2Vec2FeatureExtractor, Wav2Vec2ForSequenceClassifica
 # Import base class to establish inheritance
 from model_inference import ModelInference
 
+# Segment grouping size for scaling the positive calls threshold.
+# For every SEGMENT_GROUP_SIZE segments, require at least 1 positive prediction.
+SEGMENT_GROUP_SIZE = 10
+
 
 class HuggingFaceInference(ModelInference):  # Inherit from ModelInference
     """
@@ -35,7 +39,12 @@ class HuggingFaceInference(ModelInference):  # Inherit from ModelInference
             model_path: Path to model directory or HuggingFace Hub model ID
             device: Device to run inference on ('cuda', 'cpu', or None for auto)
             threshold: Confidence threshold for positive predictions (default: 0.5)
-            min_num_positive_calls_threshold: Minimum positive predictions for global positive (default: 3)
+            min_num_positive_calls_threshold: Minimum positive predictions for global positive classification.
+                                             The effective threshold scales with audio length: it requires
+                                             at least 1 positive per SEGMENT_GROUP_SIZE (10) segments, but
+                                             is capped at min_num_positive_calls_threshold. Formula:
+                                             min(ceil(segments/10), min_num_positive_calls_threshold).
+                                             Default: use instance value (typically 3).
         """
         super().__init__(model_path)  # Call parent constructor
         self.threshold = threshold
@@ -126,7 +135,12 @@ class HuggingFaceInference(ModelInference):  # Inherit from ModelInference
                          With hop_duration=2, a 60s audio produces ~29 confidence values.
                          With hop_duration=1, a 60s audio produces ~58 confidence values (matching FastAI).
             threshold: Confidence threshold for positive (non-other) predictions (default: use instance value)
-            min_num_positive_calls_threshold: Minimum positive predictions for global positive (default: use instance value)
+            min_num_positive_calls_threshold: Minimum positive predictions for global positive classification.
+                                             The effective threshold scales with audio length: it requires
+                                             at least 1 positive per SEGMENT_GROUP_SIZE (10) segments, but
+                                             is capped at min_num_positive_calls_threshold. Formula:
+                                             min(ceil(segments/10), min_num_positive_calls_threshold).
+                                             Default: use instance value (typically 3).
 
         Returns:
             Dictionary with keys:
@@ -294,12 +308,14 @@ class HuggingFaceInference(ModelInference):  # Inherit from ModelInference
         ]
 
         # Scale the positive calls threshold based on the number of segments.
-        # For 1-10 segments require 1 positive, 11-20 require 2, 21-30 require 3, etc.
+        # For every SEGMENT_GROUP_SIZE segments, require at least 1 positive prediction.
+        # Cap at min_num_positive_calls_threshold to avoid requiring too many for very long clips.
         total_segments = len(local_predictions)
-        scaled_threshold = max(1, (total_segments + 9) // 10)
+        scaled_threshold = (total_segments + SEGMENT_GROUP_SIZE - 1) // SEGMENT_GROUP_SIZE
+        effective_threshold = min(scaled_threshold, min_num_positive_calls_threshold)
 
         # If we have enough positive predictions, use majority vote among them.
-        if len(positive_predictions) >= scaled_threshold:
+        if len(positive_predictions) >= effective_threshold:
             # Count votes for each positive class.
             class_votes: dict[int, list[float]] = {}
             for class_id, conf in positive_predictions:

--- a/ModelTraining/src/huggingface_inference.py
+++ b/ModelTraining/src/huggingface_inference.py
@@ -293,8 +293,13 @@ class HuggingFaceInference(ModelInference):  # Inherit from ModelInference
             if class_id not in self.negative_class_ids and conf >= threshold
         ]
 
+        # Scale the positive calls threshold based on the number of segments.
+        # For 1-10 segments require 1 positive, 11-20 require 2, 21-30 require 3, etc.
+        total_segments = len(local_predictions)
+        scaled_threshold = max(1, (total_segments + 9) // 10)
+
         # If we have enough positive predictions, use majority vote among them.
-        if len(positive_predictions) >= min_num_positive_calls_threshold:
+        if len(positive_predictions) >= scaled_threshold:
             # Count votes for each positive class.
             class_votes: dict[int, list[float]] = {}
             for class_id, conf in positive_predictions:

--- a/ModelTraining/src/model_inference.py
+++ b/ModelTraining/src/model_inference.py
@@ -212,7 +212,12 @@ class FastAIModel(ModelInference):
             model_path: Path to directory containing the model file
             model_name: Name of the model file (default: "model.pkl")
             threshold: Confidence threshold for positive predictions (default: 0.5)
-            min_num_positive_calls_threshold: Minimum positive predictions for global positive (default: 3)
+            min_num_positive_calls_threshold: Minimum positive predictions for global positive classification.
+                                             For short audio clips (< 30 segments), this is automatically
+                                             scaled down (1 per 10 segments) to avoid requiring too many
+                                             positives from very short clips. The effective threshold is
+                                             min(scaled_threshold, min_num_positive_calls_threshold).
+                                             Default: 3.
         """
         self.model = load_model(model_path, model_name)
         self.threshold = threshold
@@ -346,12 +351,15 @@ class FastAIModel(ModelInference):
             segment_duration=3.0  # FastAI uses 3-second segments
         )
 
-        # Scale the positive calls threshold based on the number of segments.
-        # For 1-10 segments require 1 positive, 11-20 require 2, 21-30 require 3, etc.
+        # Calculate the effective threshold by scaling for short clips.
+        # For clips with fewer segments than min_num_positive_calls_threshold,
+        # scale down proportionally: require 1 positive per 10 segments.
+        # For longer clips, use the configured min_num_positive_calls_threshold.
         total_segments = len(result_json["local_predictions"])
         scaled_threshold = max(1, (total_segments + 9) // 10)
+        effective_threshold = min(scaled_threshold, self.min_num_positive_calls_threshold)
 
-        result_json['global_prediction'] = int(sum(result_json["local_predictions"]) >= scaled_threshold)
+        result_json['global_prediction'] = int(sum(result_json["local_predictions"]) >= effective_threshold)
         result_json['global_confidence'] = submission.loc[(submission['confidence'] > self.threshold), 'confidence'].mean()
         if pd.isnull(result_json["global_confidence"]):
             result_json["global_confidence"] = 0
@@ -502,7 +510,7 @@ def download_model_if_needed(model_path: str = "./model",
 
 
 def get_model_inference(model_path: Optional[str] = None, model_type: str = "fastai",
-                       auto_download: bool = False, model_url: Optional[str] = None, **kwargs) -> ModelInference:
+                        auto_download: bool = False, model_url: Optional[str] = None, **kwargs) -> ModelInference:
     """
     Factory function to create a model inference instance.
 

--- a/ModelTraining/src/model_inference.py
+++ b/ModelTraining/src/model_inference.py
@@ -35,6 +35,11 @@ from typing import Dict, List, Optional
 import warnings
 
 
+# Segment grouping size for scaling the positive calls threshold.
+# For every SEGMENT_GROUP_SIZE segments, require at least 1 positive prediction.
+SEGMENT_GROUP_SIZE = 10
+
+
 # Monkey-patch torchaudio.load to avoid torchcodec dependency
 # torchaudio 2.9.0+ defaults to torchcodec backend which requires additional installation
 # This patch uses soundfile directly which is already installed
@@ -351,12 +356,11 @@ class FastAIModel(ModelInference):
             segment_duration=3.0  # FastAI uses 3-second segments
         )
 
-        # Calculate the effective threshold by scaling for short clips.
-        # For clips with fewer segments than min_num_positive_calls_threshold,
-        # scale down proportionally: require 1 positive per 10 segments.
-        # For longer clips, use the configured min_num_positive_calls_threshold.
+        # Scale the positive calls threshold based on the number of segments.
+        # For every SEGMENT_GROUP_SIZE segments, require at least 1 positive prediction.
+        # Cap at min_num_positive_calls_threshold to avoid requiring too many for very long clips.
         total_segments = len(result_json["local_predictions"])
-        scaled_threshold = max(1, (total_segments + 9) // 10)
+        scaled_threshold = max(1, (total_segments + SEGMENT_GROUP_SIZE - 1) // SEGMENT_GROUP_SIZE)
         effective_threshold = min(scaled_threshold, self.min_num_positive_calls_threshold)
 
         result_json['global_prediction'] = int(sum(result_json["local_predictions"]) >= effective_threshold)

--- a/ModelTraining/src/model_inference.py
+++ b/ModelTraining/src/model_inference.py
@@ -242,8 +242,14 @@ class FastAIModel(ModelInference):
 
         # Generate 3 sec proposal with 1 sec hop length.
         threeSecList = []
-        for i in range(int(floor(max_length)-2)):
-            threeSecList.append([i, i+3])
+        max_start = max(0, int(floor(max_length) - 2))
+
+        # If audio is shorter than 3 seconds, still create one segment from 0 to max_length.
+        if max_start == 0 and max_length > 0:
+            threeSecList.append([0, min(3, max_length)])
+        else:
+            for i in range(max_start):
+                threeSecList.append([i, i + 3])
 
         # Create a proposal dictionary.
         three_sec_dict = {}
@@ -340,7 +346,12 @@ class FastAIModel(ModelInference):
             segment_duration=3.0  # FastAI uses 3-second segments
         )
 
-        result_json['global_prediction'] = int(sum(result_json["local_predictions"]) >= self.min_num_positive_calls_threshold)
+        # Scale the positive calls threshold based on the number of segments.
+        # For 1-10 segments require 1 positive, 11-20 require 2, 21-30 require 3, etc.
+        total_segments = len(result_json["local_predictions"])
+        scaled_threshold = max(1, (total_segments + 9) // 10)
+
+        result_json['global_prediction'] = int(sum(result_json["local_predictions"]) >= scaled_threshold)
         result_json['global_confidence'] = submission.loc[(submission['confidence'] > self.threshold), 'confidence'].mean()
         if pd.isnull(result_json["global_confidence"]):
             result_json["global_confidence"] = 0

--- a/ModelTraining/tests/test_run_inference.py
+++ b/ModelTraining/tests/test_run_inference.py
@@ -16,7 +16,7 @@ Tests cover:
 import sys
 import tempfile
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -87,7 +87,7 @@ def _make_huggingface_model_mock(num_local: int = 10) -> MagicMock:
     return mock_model
 
 
-def _verify_fastai_result_structure(result: Dict) -> None:
+def _verify_fastai_result_structure(result: dict) -> None:
     """Verify FastAI result has expected structure and valid values."""
     assert "probabilities" in result
     assert "global_prediction_label" in result
@@ -108,7 +108,7 @@ def _verify_fastai_result_structure(result: Dict) -> None:
     assert result["global_prediction_label"] in {"other", "whale"}
 
 
-def _verify_huggingface_result_structure(result: Dict) -> None:
+def _verify_huggingface_result_structure(result: dict) -> None:
     """Verify HuggingFace result has expected structure and valid values."""
     expected_classes = {"water", "resident", "transient", "humpback", "vessel", "jingle", "human"}
 
@@ -127,7 +127,7 @@ def _verify_huggingface_result_structure(result: Dict) -> None:
     assert result["global_prediction_label"] in expected_classes
 
 
-def _print_fastai_result(result: Dict, label: str = "") -> None:
+def _print_fastai_result(result: dict, label: str = "") -> None:
     """Print FastAI inference results for debugging."""
     prefix = f"FastAI inference results{f' on {label}' if label else ''}:"
     print(f"\n{prefix}")
@@ -136,7 +136,7 @@ def _print_fastai_result(result: Dict, label: str = "") -> None:
     print(f"  Probabilities: {result['probabilities']}")
 
 
-def _print_huggingface_result(result: Dict, label: str = "") -> None:
+def _print_huggingface_result(result: dict, label: str = "") -> None:
     """Print HuggingFace inference results for debugging."""
     prefix = f"HuggingFace inference results{f' on {label}' if label else ''}:"
     print(f"\n{prefix}")
@@ -147,7 +147,7 @@ def _print_huggingface_result(result: Dict, label: str = "") -> None:
         print(f"    {class_label}: {prob:.4f}")
 
 
-def _verify_fastai_prediction(result: Dict, audio_type: str) -> None:
+def _verify_fastai_prediction(result: dict, audio_type: str) -> None:
     """
     Verify FastAI model predicted the correct class for the audio type.
 
@@ -164,7 +164,7 @@ def _verify_fastai_prediction(result: Dict, audio_type: str) -> None:
     )
 
 
-def _verify_huggingface_prediction(result: Dict, audio_type: str, allow_category_match: bool = False) -> None:
+def _verify_huggingface_prediction(result: dict, audio_type: str, allow_category_match: bool = False) -> None:
     """
     Verify HuggingFace model predicted the correct class for the audio type.
 

--- a/ModelTraining/tests/test_run_inference.py
+++ b/ModelTraining/tests/test_run_inference.py
@@ -16,7 +16,7 @@ Tests cover:
 import sys
 import tempfile
 from pathlib import Path
-from typing import Dict, Set
+from typing import Dict
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -142,7 +142,7 @@ def _print_huggingface_result(result: Dict, label: str = "") -> None:
     print(f"\n{prefix}")
     print(f"  Global prediction: {result['global_prediction_label']}")
     print(f"  Global confidence: {result['global_confidence']:.4f}")
-    print(f"  Probabilities:")
+    print("  Probabilities:")
     for class_label, prob in sorted(result["probabilities"].items()):
         print(f"    {class_label}: {prob:.4f}")
 
@@ -506,7 +506,7 @@ class TestIntegrationWithRealModels:
 
     # Shared fixtures for model paths.
     @pytest.fixture
-    def fastai_model_path(self):
+    def fastai_model_path(self) -> str:
         """Path to the FastAI model directory."""
         path = Path("model")
         if not path.exists():
@@ -514,7 +514,7 @@ class TestIntegrationWithRealModels:
         return str(path)
 
     @pytest.fixture
-    def huggingface_model_path(self):
+    def huggingface_model_path(self) -> str:
         """Path to the HuggingFace multiclass model directory."""
         path = Path("model/multiclass")
         if not path.exists():
@@ -523,7 +523,7 @@ class TestIntegrationWithRealModels:
 
     # Fixtures for test wav files (one per audio type).
     @pytest.fixture
-    def resident_wav_path(self):
+    def resident_wav_path(self) -> str:
         """Path to a real resident orca wav file for testing."""
         path = Path("output/wav/resident/rpi-andrews-bay_2026_02_16_22_52_59_PST.wav")
         if not path.exists():
@@ -531,7 +531,7 @@ class TestIntegrationWithRealModels:
         return str(path)
 
     @pytest.fixture
-    def transient_wav_path(self):
+    def transient_wav_path(self) -> str:
         """Path to a real transient orca wav file for testing."""
         path = Path("output/wav/transient/rpi-sunset-bay_2024_12_19_12_39_03_PST.wav")
         if not path.exists():
@@ -539,7 +539,7 @@ class TestIntegrationWithRealModels:
         return str(path)
 
     @pytest.fixture
-    def humpback_wav_path(self):
+    def humpback_wav_path(self) -> str:
         """Path to a real humpback whale wav file for testing."""
         path = Path("output/wav/humpback/rpi-orcasound-lab_2025_12_19_04_55_55_PST.wav")
         if not path.exists():
@@ -547,7 +547,7 @@ class TestIntegrationWithRealModels:
         return str(path)
 
     @pytest.fixture
-    def vessel_wav_path(self):
+    def vessel_wav_path(self) -> str:
         """Path to a real vessel noise wav file for testing."""
         path = Path("output/wav/vessel/rpi-mast-center_2026_01_26_19_01_25_PST.wav")
         if not path.exists():
@@ -555,7 +555,7 @@ class TestIntegrationWithRealModels:
         return str(path)
 
     @pytest.fixture
-    def water_wav_path(self):
+    def water_wav_path(self) -> str:
         """Path to a real water/ambient noise wav file for testing."""
         path = Path("output/wav/water/rpi-bush-point_2025_06_29_04_19_09_PST.wav")
         if not path.exists():
@@ -563,7 +563,7 @@ class TestIntegrationWithRealModels:
         return str(path)
 
     @pytest.fixture
-    def human_wav_path(self):
+    def human_wav_path(self) -> str:
         """Path to a real human voice wav file for testing."""
         path = Path("output/wav/human/rpi-sunset-bay_2024_07_23_11_32_48_PST.wav")
         if not path.exists():
@@ -571,7 +571,7 @@ class TestIntegrationWithRealModels:
         return str(path)
 
     @pytest.fixture
-    def jingle_wav_path(self):
+    def jingle_wav_path(self) -> str:
         """Path to a real jingle/signal wav file for testing."""
         path = Path("output/wav/jingle/rpi-north-sjc_2024_11_01_00_47_53_PST.wav")
         if not path.exists():
@@ -588,7 +588,13 @@ class TestIntegrationWithRealModels:
         ("human_wav_path", "human"),
         ("jingle_wav_path", "jingle"),
     ])
-    def test_fastai_model_inference(self, wav_fixture, label, fastai_model_path, request):
+    def test_fastai_model_inference(
+        self,
+        wav_fixture: str,
+        label: str,
+        fastai_model_path: str,
+        request: pytest.FixtureRequest
+    ) -> None:
         """Test FastAI model inference on various audio types."""
         from run_inference import run_inference
 
@@ -611,7 +617,14 @@ class TestIntegrationWithRealModels:
         ("human_wav_path", "human", True),  # Currently predicts "water", accept category match.
         ("jingle_wav_path", "jingle", True),  # Currently predicts "water", accept category match.
     ])
-    def test_huggingface_model_inference(self, wav_fixture, label, allow_category_match, huggingface_model_path, request):
+    def test_huggingface_model_inference(
+        self,
+        wav_fixture: str,
+        label: str,
+        allow_category_match: bool,
+        huggingface_model_path: str,
+        request: pytest.FixtureRequest
+    ) -> None:
         """Test HuggingFace model inference on various audio types."""
         from run_inference import run_inference
 
@@ -639,7 +652,13 @@ class TestIntegrationWithRealModels:
         ("jingle_wav_path", "fastai", "fastai_model_path"),
         ("jingle_wav_path", "huggingface", "huggingface_model_path"),
     ])
-    def test_cli_integration(self, wav_fixture, model_type, model_path_fixture, request):
+    def test_cli_integration(
+        self,
+        wav_fixture: str,
+        model_type: str,
+        model_path_fixture: str,
+        request: pytest.FixtureRequest
+    ) -> None:
         """Test CLI integration with various audio types and models."""
         from run_inference import main
 

--- a/ModelTraining/tests/test_run_inference.py
+++ b/ModelTraining/tests/test_run_inference.py
@@ -10,11 +10,13 @@ Tests cover:
 - Per-class probability output format and values
 - CLI argument validation (invalid model type)
 - Missing wav file error handling
+- Integration tests with real models (if available)
 """
 
 import sys
 import tempfile
 from pathlib import Path
+from typing import Dict, Set
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -83,6 +85,126 @@ def _make_huggingface_model_mock(num_local: int = 10) -> MagicMock:
         "segment_duration": 3.0,
     }
     return mock_model
+
+
+def _verify_fastai_result_structure(result: Dict) -> None:
+    """Verify FastAI result has expected structure and valid values."""
+    assert "probabilities" in result
+    assert "global_prediction_label" in result
+    assert "global_confidence" in result
+
+    # Verify binary classes.
+    assert set(result["probabilities"].keys()) == {"other", "whale"}
+
+    # Verify probabilities sum to 1.0.
+    total_prob = sum(result["probabilities"].values())
+    assert abs(total_prob - 1.0) < 1e-3
+
+    # Verify all values in valid range.
+    for prob in result["probabilities"].values():
+        assert 0.0 <= prob <= 1.0
+
+    assert 0.0 <= result["global_confidence"] <= 1.0
+    assert result["global_prediction_label"] in {"other", "whale"}
+
+
+def _verify_huggingface_result_structure(result: Dict) -> None:
+    """Verify HuggingFace result has expected structure and valid values."""
+    expected_classes = {"water", "resident", "transient", "humpback", "vessel", "jingle", "human"}
+
+    assert "probabilities" in result
+    assert "global_prediction_label" in result
+    assert "global_confidence" in result
+
+    # Verify all 7 classes are present.
+    assert set(result["probabilities"].keys()) == expected_classes
+
+    # Verify all values in valid range.
+    for prob in result["probabilities"].values():
+        assert 0.0 <= prob <= 1.0
+
+    assert 0.0 <= result["global_confidence"] <= 1.0
+    assert result["global_prediction_label"] in expected_classes
+
+
+def _print_fastai_result(result: Dict, label: str = "") -> None:
+    """Print FastAI inference results for debugging."""
+    prefix = f"FastAI inference results{f' on {label}' if label else ''}:"
+    print(f"\n{prefix}")
+    print(f"  Global prediction: {result['global_prediction_label']}")
+    print(f"  Global confidence: {result['global_confidence']:.4f}")
+    print(f"  Probabilities: {result['probabilities']}")
+
+
+def _print_huggingface_result(result: Dict, label: str = "") -> None:
+    """Print HuggingFace inference results for debugging."""
+    prefix = f"HuggingFace inference results{f' on {label}' if label else ''}:"
+    print(f"\n{prefix}")
+    print(f"  Global prediction: {result['global_prediction_label']}")
+    print(f"  Global confidence: {result['global_confidence']:.4f}")
+    print(f"  Probabilities:")
+    for class_label, prob in sorted(result["probabilities"].items()):
+        print(f"    {class_label}: {prob:.4f}")
+
+
+def _verify_fastai_prediction(result: Dict, audio_type: str) -> None:
+    """
+    Verify FastAI model predicted the correct class for the audio type.
+
+    For whale audio (resident, transient, humpback), expect "whale".
+    For non-whale audio (water, vessel, human, jingle), expect "other".
+    """
+    whale_classes = {"resident", "transient", "humpback"}
+    expected = "whale" if audio_type in whale_classes else "other"
+
+    actual = result["global_prediction_label"]
+    assert actual == expected, (
+        f"FastAI model predicted '{actual}' for {audio_type} audio, "
+        f"but expected '{expected}'"
+    )
+
+
+def _verify_huggingface_prediction(result: Dict, audio_type: str, allow_category_match: bool = False) -> None:
+    """
+    Verify HuggingFace model predicted the correct class for the audio type.
+
+    Args:
+        result: Inference result dictionary.
+        audio_type: Expected audio type (resident, transient, humpback, water, vessel, human, jingle).
+        allow_category_match: If True, accept category match (whale vs non-whale) instead of exact match.
+                              Defaults to False, requiring exact match for all classes.
+
+    For all classes:
+        - By default (allow_category_match=False), requires exact match.
+        - If allow_category_match=True, accepts category match:
+          - For whale classes: accepts any whale class.
+          - For non-whale classes: accepts any non-whale class.
+    """
+    actual = result["global_prediction_label"]
+
+    whale_classes = {"resident", "transient", "humpback"}
+    non_whale_classes = {"water", "vessel", "human", "jingle"}
+
+    if allow_category_match:
+        # Category match mode.
+        if audio_type in whale_classes:
+            # Accept any whale class.
+            assert actual in whale_classes, (
+                f"HuggingFace model predicted '{actual}' for {audio_type} audio, "
+                f"but expected one of {whale_classes}"
+            )
+        elif audio_type in non_whale_classes:
+            # Accept any non-whale class.
+            assert actual in non_whale_classes, (
+                f"HuggingFace model predicted '{actual}' for {audio_type} audio, "
+                f"but expected one of {non_whale_classes}"
+            )
+    else:
+        # Exact match required.
+        assert actual == audio_type, (
+            f"HuggingFace model predicted '{actual}' for {audio_type} audio, "
+            f"but expected exact match '{audio_type}'"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -368,3 +490,168 @@ class TestMainCLI:
         assert "whale" in captured.out
         assert "fastai" in captured.out
         assert "0.7000" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Integration tests with real models (if available)
+# ---------------------------------------------------------------------------
+
+class TestIntegrationWithRealModels:
+    """
+    Integration tests that run inference on real wav files with real models.
+
+    These tests are skipped if the required models or wav files are not present.
+    They verify end-to-end functionality with actual model weights.
+    """
+
+    # Shared fixtures for model paths.
+    @pytest.fixture
+    def fastai_model_path(self):
+        """Path to the FastAI model directory."""
+        path = Path("model")
+        if not path.exists():
+            pytest.skip(f"FastAI model directory not found: {path}")
+        return str(path)
+
+    @pytest.fixture
+    def huggingface_model_path(self):
+        """Path to the HuggingFace multiclass model directory."""
+        path = Path("model/multiclass")
+        if not path.exists():
+            pytest.skip(f"HuggingFace model directory not found: {path}")
+        return str(path)
+
+    # Fixtures for test wav files (one per audio type).
+    @pytest.fixture
+    def resident_wav_path(self):
+        """Path to a real resident orca wav file for testing."""
+        path = Path("output/wav/resident/rpi-andrews-bay_2026_02_16_22_52_59_PST.wav")
+        if not path.exists():
+            pytest.skip(f"Test wav file not found: {path}")
+        return str(path)
+
+    @pytest.fixture
+    def transient_wav_path(self):
+        """Path to a real transient orca wav file for testing."""
+        path = Path("output/wav/transient/rpi-sunset-bay_2024_12_19_12_39_03_PST.wav")
+        if not path.exists():
+            pytest.skip(f"Test wav file not found: {path}")
+        return str(path)
+
+    @pytest.fixture
+    def humpback_wav_path(self):
+        """Path to a real humpback whale wav file for testing."""
+        path = Path("output/wav/humpback/rpi-orcasound-lab_2025_12_19_04_55_55_PST.wav")
+        if not path.exists():
+            pytest.skip(f"Test wav file not found: {path}")
+        return str(path)
+
+    @pytest.fixture
+    def vessel_wav_path(self):
+        """Path to a real vessel noise wav file for testing."""
+        path = Path("output/wav/vessel/rpi-mast-center_2026_01_26_19_01_25_PST.wav")
+        if not path.exists():
+            pytest.skip(f"Test wav file not found: {path}")
+        return str(path)
+
+    @pytest.fixture
+    def water_wav_path(self):
+        """Path to a real water/ambient noise wav file for testing."""
+        path = Path("output/wav/water/rpi-bush-point_2025_06_29_04_19_09_PST.wav")
+        if not path.exists():
+            pytest.skip(f"Test wav file not found: {path}")
+        return str(path)
+
+    @pytest.fixture
+    def human_wav_path(self):
+        """Path to a real human voice wav file for testing."""
+        path = Path("output/wav/human/rpi-sunset-bay_2024_07_23_11_32_48_PST.wav")
+        if not path.exists():
+            pytest.skip(f"Test wav file not found: {path}")
+        return str(path)
+
+    @pytest.fixture
+    def jingle_wav_path(self):
+        """Path to a real jingle/signal wav file for testing."""
+        path = Path("output/wav/jingle/rpi-north-sjc_2024_11_01_00_47_53_PST.wav")
+        if not path.exists():
+            pytest.skip(f"Test wav file not found: {path}")
+        return str(path)
+
+    # Parametrized tests for FastAI model on different audio types.
+    @pytest.mark.parametrize("wav_fixture,label", [
+        ("resident_wav_path", "resident"),
+        ("transient_wav_path", "transient"),
+        ("humpback_wav_path", "humpback"),
+        ("vessel_wav_path", "vessel"),
+        ("water_wav_path", "water"),
+        ("human_wav_path", "human"),
+        ("jingle_wav_path", "jingle"),
+    ])
+    def test_fastai_model_inference(self, wav_fixture, label, fastai_model_path, request):
+        """Test FastAI model inference on various audio types."""
+        from run_inference import run_inference
+
+        wav_path = request.getfixturevalue(wav_fixture)
+        result = run_inference(wav_path, model_type="fastai", model_path=fastai_model_path)
+
+        _verify_fastai_result_structure(result)
+        _verify_fastai_prediction(result, label)
+        _print_fastai_result(result, label)
+
+    # Parametrized tests for HuggingFace model on different audio types.
+    # By default, exact match is required for all classes.
+    # Set allow_category_match=True for specific files where exact match would fail.
+    @pytest.mark.parametrize("wav_fixture,label,allow_category_match", [
+        ("resident_wav_path", "resident", False),
+        ("transient_wav_path", "transient", False),
+        ("humpback_wav_path", "humpback", False),
+        ("vessel_wav_path", "vessel", True),  # Currently predicts "water", accept category match.
+        ("water_wav_path", "water", False),
+        ("human_wav_path", "human", True),  # Currently predicts "water", accept category match.
+        ("jingle_wav_path", "jingle", True),  # Currently predicts "water", accept category match.
+    ])
+    def test_huggingface_model_inference(self, wav_fixture, label, allow_category_match, huggingface_model_path, request):
+        """Test HuggingFace model inference on various audio types."""
+        from run_inference import run_inference
+
+        wav_path = request.getfixturevalue(wav_fixture)
+        result = run_inference(wav_path, model_type="huggingface", model_path=huggingface_model_path)
+
+        _verify_huggingface_result_structure(result)
+        _verify_huggingface_prediction(result, label, allow_category_match=allow_category_match)
+        _print_huggingface_result(result, label)
+
+    # Parametrized CLI integration tests.
+    @pytest.mark.parametrize("wav_fixture,model_type,model_path_fixture", [
+        ("resident_wav_path", "fastai", "fastai_model_path"),
+        ("resident_wav_path", "huggingface", "huggingface_model_path"),
+        ("transient_wav_path", "fastai", "fastai_model_path"),
+        ("transient_wav_path", "huggingface", "huggingface_model_path"),
+        ("humpback_wav_path", "fastai", "fastai_model_path"),
+        ("humpback_wav_path", "huggingface", "huggingface_model_path"),
+        ("vessel_wav_path", "fastai", "fastai_model_path"),
+        ("vessel_wav_path", "huggingface", "huggingface_model_path"),
+        ("water_wav_path", "fastai", "fastai_model_path"),
+        ("water_wav_path", "huggingface", "huggingface_model_path"),
+        ("human_wav_path", "fastai", "fastai_model_path"),
+        ("human_wav_path", "huggingface", "huggingface_model_path"),
+        ("jingle_wav_path", "fastai", "fastai_model_path"),
+        ("jingle_wav_path", "huggingface", "huggingface_model_path"),
+    ])
+    def test_cli_integration(self, wav_fixture, model_type, model_path_fixture, request):
+        """Test CLI integration with various audio types and models."""
+        from run_inference import main
+
+        wav_path = request.getfixturevalue(wav_fixture)
+        model_path = request.getfixturevalue(model_path_fixture)
+
+        with patch("sys.argv", [
+            "run_inference.py",
+            wav_path,
+            "--model", model_type,
+            "--model-path", model_path
+        ]):
+            exit_code = main()
+
+        assert exit_code == 0

--- a/ModelTraining/tests/test_run_inference.py
+++ b/ModelTraining/tests/test_run_inference.py
@@ -16,7 +16,7 @@ Tests cover:
 import sys
 import tempfile
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -606,33 +606,38 @@ class TestIntegrationWithRealModels:
         _print_fastai_result(result, label)
 
     # Parametrized tests for HuggingFace model on different audio types.
-    # By default, exact match is required for all classes.
-    # Set allow_category_match=True for specific files where exact match would fail.
-    @pytest.mark.parametrize("wav_fixture,label,allow_category_match", [
-        ("resident_wav_path", "resident", False),
-        ("transient_wav_path", "transient", False),
-        ("humpback_wav_path", "humpback", False),
-        ("vessel_wav_path", "vessel", True),  # Currently predicts "water", accept category match.
-        ("water_wav_path", "water", False),
-        ("human_wav_path", "human", True),  # Currently predicts "water", accept category match.
-        ("jingle_wav_path", "jingle", True),  # Currently predicts "water", accept category match.
+    # Tests marked with xfail indicate known model defects that should be fixed.
+    # When the model is improved, these will fail (which is good!) and should be unmarked.
+    @pytest.mark.parametrize("wav_fixture,label,xfail_reason", [
+        ("resident_wav_path", "resident", None),
+        ("transient_wav_path", "transient", None),
+        ("humpback_wav_path", "humpback", None),
+        ("vessel_wav_path", "vessel", "Model currently predicts 'water' instead of 'vessel'"),
+        ("water_wav_path", "water", None),
+        ("human_wav_path", "human", "Model currently predicts 'water' instead of 'human'"),
+        ("jingle_wav_path", "jingle", "Model currently predicts 'water' instead of 'jingle'"),
     ])
     def test_huggingface_model_inference(
         self,
         wav_fixture: str,
         label: str,
-        allow_category_match: bool,
+        xfail_reason: Optional[str],
         huggingface_model_path: str,
         request: pytest.FixtureRequest
     ) -> None:
         """Test HuggingFace model inference on various audio types."""
         from run_inference import run_inference
+        
+        # Apply xfail marker if this test case is expected to fail.
+        if xfail_reason:
+            request.node.add_marker(pytest.mark.xfail(reason=xfail_reason, strict=True))
 
         wav_path = request.getfixturevalue(wav_fixture)
         result = run_inference(wav_path, model_type="huggingface", model_path=huggingface_model_path)
 
         _verify_huggingface_result_structure(result)
-        _verify_huggingface_prediction(result, label, allow_category_match=allow_category_match)
+        # Always require exact match - no category matching allowed.
+        _verify_huggingface_prediction(result, label, allow_category_match=False)
         _print_huggingface_result(result, label)
 
     # Parametrized CLI integration tests.


### PR DESCRIPTION
Fixes #98 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Decision thresholds now scale dynamically with segment count, improving inference consistency.
  * Improved handling of short audio so a sensible single-segment inference is produced instead of empty results.

* **Tests**
  * Added end-to-end integration tests for model inference and CLI behavior using real model and audio fixtures; includes new validators and debug helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->